### PR TITLE
fix(about): restore hero layout layering and marquee alignment

### DIFF
--- a/components/About.css
+++ b/components/About.css
@@ -50,7 +50,7 @@ body {
   padding: 5vw;
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  grid-template-rows: 80px 170px auto 1fr;
+  grid-template-rows: 80px 170px 1fr 80px;
   position: relative;
   background-color: #566246;
   color: #f4f4f4;
@@ -74,7 +74,7 @@ body {
   background-position: center;
   pointer-events: none;
   opacity: 0.7;
-  z-index: 3;
+  z-index: 2;
 }
 
 /* Canvas for drawing grid */
@@ -89,14 +89,8 @@ body {
 }
 
 /* Ensure all content appears above the canvas but below dots */
-.hero>*:not(canvas) {
-  position: relative;
-  z-index: 2;
-}
-
-.hero::after {
-  position: relative;
-  z-index: 1;
+.hero > *:not(canvas):not(.big-word) {
+  z-index: 3;
 }
 
 .label {
@@ -127,8 +121,9 @@ body {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto auto;
-  gap: 40px;
+  gap: 80px;
   margin-top: 50px;
+  align-content: start;
 }
 
 .note-1 {
@@ -164,7 +159,7 @@ body {
 
 .big-word {
   position: absolute;
-  bottom: 4vw;
+  bottom: 2.5vw;
   left: 1vw;
   font-family: 'Playfair Display', serif;
   font-size: clamp(120px, 16vw, 240px);
@@ -915,9 +910,10 @@ body {
   height: 40px;
   overflow: hidden;
   position: absolute;
-  bottom: 0;
+  bottom: 50px;
   left: 0;
   right: 0;
+  transform: translateY(100%);
   background-color: #c5918b;
   color: #385338;
   font-size: 15px;
@@ -1237,6 +1233,11 @@ body {
     padding: 6vw;
     grid-template-columns: repeat(12, 1fr);
     grid-template-rows: 60px 140px auto 1fr;
+  }
+
+  .hero-scrolling-text {
+    bottom: 35px;
+    transform: translateY(100%);
   }
 
   .label {
@@ -2028,7 +2029,7 @@ body {
   }
 
   .big-word {
-   
+    bottom: 12vw !important;
     left: 2vw;
   }
 

--- a/components/About.js
+++ b/components/About.js
@@ -626,63 +626,6 @@ function About() {
       experienceCardsRef.current.push(el);
     }
   };
-  // Add this useEffect to handle scroll locking at the bottom
-  useEffect(() => {
-    const handleScrollLock = () => {
-      const experienceSection = experienceSectionRef.current;
-      if (!experienceSection) return;
-
-      const rect = experienceSection.getBoundingClientRect();
-      const isAtBottom = rect.bottom <= window.innerHeight;
-      const scrollPosition = window.scrollY;
-      const maxScroll =
-        document.documentElement.scrollHeight - window.innerHeight;
-
-      // If we're at the bottom of the page
-      if (scrollPosition >= maxScroll - 10) {
-        // 10px threshold
-        // Lock scrolling by preventing default only when trying to scroll past
-        document.body.style.overflowY = "hidden";
-      } else {
-        // Re-enable scrolling
-        document.body.style.overflowY = "";
-      }
-    };
-
-    // Also prevent wheel events when at the bottom and trying to scroll further
-    const preventOverscroll = (e) => {
-      const experienceSection = experienceSectionRef.current;
-      if (!experienceSection) return;
-
-      const scrollPosition = window.scrollY;
-      const maxScroll =
-        document.documentElement.scrollHeight - window.innerHeight;
-      const deltaY = e.deltaY;
-
-      // If at the bottom and trying to scroll down
-      if (scrollPosition >= maxScroll - 5 && deltaY > 0) {
-        e.preventDefault();
-      }
-
-      // If at the top and trying to scroll up
-      if (scrollPosition <= 5 && deltaY < 0) {
-        e.preventDefault();
-      }
-    };
-
-    window.addEventListener("scroll", handleScrollLock);
-    window.addEventListener("wheel", preventOverscroll, { passive: false });
-
-    handleScrollLock(); // Check initial state
-
-    return () => {
-      window.removeEventListener("scroll", handleScrollLock);
-      window.removeEventListener("wheel", preventOverscroll);
-      // Clean up styles when component unmounts
-      document.body.style.overflowY = "";
-    };
-  }, []);
-
   return (
     <>
       <div className="about-container">


### PR DESCRIPTION
## Summary
- remove the About page bottom scroll-lock logic that forced `body` overflow hidden near the end of the page and could trap users at page boundaries
- correct hero stacking behavior so the dotted background overlay renders again while keeping hero content readable and preventing the signature text from being unexpectedly shifted upward
- tune hero typography/marquee positioning for desktop and responsive breakpoints so the `Osumgba Benson` wordmark and scrolling strip sit in stable, intended positions

## Why
The About hero had conflicting positioning rules that caused layout drift (wordmark too high), inconsistent z-index layering (dot pattern disappearing), and brittle scrolling behavior. This change simplifies the layering model and removes JS-based scroll interference so the section behaves predictably across viewport sizes.

## Scope
- `components/About.js`
- `components/About.css`

## Validation
- verified styles compile and branch pushes cleanly
- manually validated resulting CSS/JS changes for hero stacking and positioning consistency in the updated files